### PR TITLE
add Packed type

### DIFF
--- a/hlbc/src/deser.rs
+++ b/hlbc/src/deser.rs
@@ -197,6 +197,7 @@ impl<T: Read> ReadHlExt for T {
             19 => Ok(Type::Null(self.read_type_ref()?)),
             20 => Ok(Type::Method(self.read_type_fun()?)),
             21 => Ok(Type::Struct(self.read_type_obj()?)),
+            22 => Ok(Type::Packed(self.read_type_ref()?)),
             other => Err(Error::MalformedBytecode(format!(
                 "Invalid type kind '{other}'"
             ))),

--- a/hlbc/src/fmt.rs
+++ b/hlbc/src/fmt.rs
@@ -160,6 +160,9 @@ impl Type {
                     .collect();
                 format!("{}<{}>", name.display(ctx), fields.join(", "))
             }
+            Type::Packed(reftype) => {
+                format!("packed<{}>", reftype.display_rec(ctx, parents.clone()))
+            }
         }
     }
 }

--- a/hlbc/src/ser.rs
+++ b/hlbc/src/ser.rs
@@ -190,6 +190,10 @@ impl<T: Write> WriteHlExt for T {
                 self.write_u8(21)?;
                 self.write_type_obj(obj)?;
             }
+            Type::Packed(inner) => {
+                self.write_u8(22)?;
+                self.write_vi32(inner.0 as i32)?;
+            }
         }
         Ok(())
     }

--- a/hlbc/src/types.rs
+++ b/hlbc/src/types.rs
@@ -155,6 +155,7 @@ pub enum Type {
     Null(RefType),
     Method(TypeFun),
     Struct(TypeObj),
+    Packed(RefType),
 }
 
 impl Type {


### PR DESCRIPTION
Wanting to look at the new [wartales](https://store.steampowered.com/app/1527950/Wartales/) game, and it looks that a new base type was added to hashlink called [PACKED](https://github.com/HaxeFoundation/hashlink/blob/master/src/hl.h#L345). Apologies if it isnt implemented correctly, but hlboot reads without crashing with these fixes.