### PR TITLE
Fix write_var bits

### DIFF
--- a/crates/hlbc/src/write.rs
+++ b/crates/hlbc/src/write.rs
@@ -315,8 +315,8 @@ pub(crate) fn write_var(w: &mut impl Write, value: i32) -> Result<()> {
             });
         } else {
             w.write_u8(((value >> 24) | 0xE0) as u8)?;
-            w.write_u8(((value >> 16) | 0xFF) as u8)?;
-            w.write_u8(((value >> 8) | 0xFF) as u8)?;
+            w.write_u8(((value >> 16) & 0xFF) as u8)?;
+            w.write_u8(((value >> 8) & 0xFF) as u8)?;
             w.write_u8((value & 0xFF) as u8)?;
         }
     } else if value < 0x80 {
@@ -331,8 +331,8 @@ pub(crate) fn write_var(w: &mut impl Write, value: i32) -> Result<()> {
         });
     } else {
         w.write_u8(((value >> 24) | 0xC0) as u8)?;
-        w.write_u8(((value >> 16) | 0xFF) as u8)?;
-        w.write_u8(((value >> 8) | 0xFF) as u8)?;
+        w.write_u8(((value >> 16) & 0xFF) as u8)?;
+        w.write_u8(((value >> 8) & 0xFF) as u8)?;
         w.write_u8((value & 0xFF) as u8)?;
     }
     Ok(())


### PR DESCRIPTION
Thank you for making this project.

Copy-paste typo, "|" wasn't replaced with "&", so all bits were set to ones instead of masking them.
`deserialize(serialize(bytecode))` failed for that reason.